### PR TITLE
Refactor/apply clean arch into share check

### DIFF
--- a/lib/src/domain/check/entities/check.dart
+++ b/lib/src/domain/check/entities/check.dart
@@ -1,4 +1,4 @@
-class CheckModel {
+class Check {
   DateTime? creationDate;
   String? id;
   // TODO: verificar a necessidade de adicionar uma localização
@@ -17,7 +17,7 @@ class CheckModel {
   double individualPriceWhoIsDrinking;
   int totalPeople;
 
-  CheckModel({
+  Check({
     this.creationDate,
     this.id,
     this.totalValue = 0,
@@ -30,7 +30,7 @@ class CheckModel {
     this.individualPriceWhoIsDrinking = 0,
     this.totalPeople = 1,
   });
-   CheckModel copyWith({
+   Check copyWith({
     String? id,
     DateTime? creationDate,
     double? totalValue,
@@ -43,7 +43,7 @@ class CheckModel {
     double? individualPriceWhoIsDrinking,
     int? totalPeople,
   }) {
-    return CheckModel(
+    return Check(
       id: id ?? this.id,
       creationDate: creationDate ?? this.creationDate,
       totalValue: totalValue ?? this.totalValue,

--- a/lib/src/domain/check/entities/result_get_all_checks.dart
+++ b/lib/src/domain/check/entities/result_get_all_checks.dart
@@ -1,7 +1,0 @@
-import 'check_model.dart';
-
-class ResultGetAllChecks {
-  List<CheckModel> checks;
-
-  ResultGetAllChecks({required this.checks});
-}

--- a/lib/src/domain/check/errors/erros.dart
+++ b/lib/src/domain/check/errors/erros.dart
@@ -10,3 +10,10 @@ class LocalDatasouceError implements Failure {
 
   LocalDatasouceError({required this.message});
 }
+
+class CheckSharingServiceError implements Failure {
+  @override
+  final String message;
+
+  CheckSharingServiceError({required this.message});
+}

--- a/lib/src/domain/check/repositories/check_repository.dart
+++ b/lib/src/domain/check/repositories/check_repository.dart
@@ -1,13 +1,12 @@
 import 'package:dartz/dartz.dart';
 
-import '../entities/check_model.dart';
-import '../entities/result_get_all_checks.dart';
+import '../entities/check.dart';
 import '../errors/erros.dart';
 
 abstract class CheckRepository {
-  Future<Either<Failure, ResultGetAllChecks>> getAllChecks();
+  Future<Either<Failure, List<Check>>> getAllChecks();
 
   Future<Either<Failure, void>> deleteCheck({required String checkId});
 
-    Future<Either<Failure, void>> createCheck({required CheckModel check});
+  Future<Either<Failure, void>> createCheck({required Check check});
 }

--- a/lib/src/domain/check/services/check_sharing_service.dart
+++ b/lib/src/domain/check/services/check_sharing_service.dart
@@ -1,0 +1,13 @@
+import 'dart:typed_data';
+
+import 'package:dartz/dartz.dart';
+
+import '../entities/check.dart';
+import '../errors/erros.dart';
+
+abstract class CheckSharingService {
+  Future<Either<Failure, Uint8List>> generateCheckImage(Check check);
+
+  Future<Either<Failure, bool>> shareCheckImage(
+      {required Uint8List imageBytes});
+}

--- a/lib/src/domain/check/usecases/get_all_checks.dart
+++ b/lib/src/domain/check/usecases/get_all_checks.dart
@@ -1,11 +1,11 @@
 import 'package:dartz/dartz.dart';
+import 'package:racha_racha/src/domain/check/entities/check.dart';
 
-import '../entities/result_get_all_checks.dart';
 import '../errors/erros.dart';
 import '../repositories/check_repository.dart';
 
 abstract class GetAllChecks {
-  Future<Either<Failure, ResultGetAllChecks>> call();
+  Future<Either<Failure, List<Check>>> call();
 }
 
 class GetAllChecksImpl implements GetAllChecks {
@@ -16,7 +16,7 @@ class GetAllChecksImpl implements GetAllChecks {
   });
 
   @override
-  Future<Either<Failure, ResultGetAllChecks>> call() async {
+  Future<Either<Failure, List<Check>>> call() async {
     return repository.getAllChecks();
   }
 }

--- a/lib/src/domain/check/usecases/share_check.dart
+++ b/lib/src/domain/check/usecases/share_check.dart
@@ -1,15 +1,28 @@
 import 'package:dartz/dartz.dart';
 
+import '../entities/check.dart';
 import '../errors/erros.dart';
+import '../services/check_sharing_service.dart';
 
 abstract class ShareCheck {
-  Future<Either<Failure, bool>> call();
+  Future<Either<Failure, bool>> call({required Check check});
 }
 
 class ShareCheckImpl implements ShareCheck {
+  final CheckSharingService _sharingService;
+
+  ShareCheckImpl({required CheckSharingService sharingService})
+      : _sharingService = sharingService;
+
   @override
-  Future<Either<Failure, bool>> call() {
-    // TODO: implement call
-    throw UnimplementedError();
+  Future<Either<Failure, bool>> call({required Check check}) async {
+    final imageResult = await _sharingService.generateCheckImage(check);
+
+    return imageResult.fold(
+      (failure) => Left(failure),
+      (imagePath) async => await _sharingService.shareCheckImage(
+        imageBytes: imagePath,
+      ),
+    );
   }
 }

--- a/lib/src/external/check/datasourcers/sqflite_check_datasource.dart
+++ b/lib/src/external/check/datasourcers/sqflite_check_datasource.dart
@@ -1,10 +1,9 @@
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
-import 'package:uuid/uuid.dart'; // Importando o pacote uuid
+import 'package:uuid/uuid.dart';
 import '../../../infra/check/adapters/sqflite_check_adapter.dart';
 import '../../../infra/check/datasourcers/local_check_datasource.dart';
-import '../../../domain/check/entities/check_model.dart';
-import '../../../domain/check/entities/result_get_all_checks.dart';
+import '../../../domain/check/entities/check.dart';
 
 class SqfliteCheckDatasource implements LocalCheckDatasource {
   static const String _tableName = 'checks';
@@ -48,14 +47,12 @@ class SqfliteCheckDatasource implements LocalCheckDatasource {
   }
 
   @override
-  Future<void> createCheck({required CheckModel check}) async {
+  Future<void> createCheck({required Check check}) async {
     try {
       final db = await _db; // Espera até que o banco de dados esteja pronto
 
-      // Atribuindo um id único ao check
-      final id = const Uuid().v4(); // Gera um ID único
-      final updatedCheck =
-          check.copyWith(id: id); // Copia o check e define o id gerado
+      final id = const Uuid().v4();
+      final updatedCheck = check.copyWith(id: id);
 
       final checkMap = SqfliteCheckAdapter.toMap(updatedCheck);
       await db.insert(
@@ -69,7 +66,7 @@ class SqfliteCheckDatasource implements LocalCheckDatasource {
   }
 
   @override
-  Future<ResultGetAllChecks> getAllChecks() async {
+  Future<List<Check>> getAllChecks() async {
     try {
       final db = await _db; // Espera até que o banco de dados esteja pronto
       final List<Map<String, dynamic>> maps = await db.query(
@@ -79,7 +76,7 @@ class SqfliteCheckDatasource implements LocalCheckDatasource {
 
       final checks = maps.map(SqfliteCheckAdapter.fromMap).toList();
 
-      return ResultGetAllChecks(checks: checks);
+      return checks;
     } catch (e) {
       throw Exception('Erro ao buscar todos os checks: $e');
     }
@@ -88,7 +85,7 @@ class SqfliteCheckDatasource implements LocalCheckDatasource {
   @override
   Future<void> deleteCheck({required String checkId}) async {
     try {
-      final db = await _db; // Espera até que o banco de dados esteja pronto
+      final db = await _db;
       await db.delete(
         _tableName,
         where: 'id = ?',

--- a/lib/src/external/services/generate_check_service_impl.dart
+++ b/lib/src/external/services/generate_check_service_impl.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
-import '../../domain/check/entities/check_model.dart';
+import '../../domain/check/entities/check.dart';
 import '../../infra/services/generate_check_service.dart';
 
 class GenerateCheckServiceImpl implements GenerateCheckService {
@@ -13,7 +13,7 @@ class GenerateCheckServiceImpl implements GenerateCheckService {
   late Color _textColor;
 
   @override
-  Future<Uint8List> generateImage({required CheckModel check}) async {
+  Future<Uint8List> generateImage({required Check check}) async {
     final ui.PictureRecorder recorder = ui.PictureRecorder();
     _canvas = Canvas(recorder);
     _size = const Size(800, 700);
@@ -49,7 +49,7 @@ class GenerateCheckServiceImpl implements GenerateCheckService {
         color: Colors.white, fontSize: 24);
   }
 
-  void _drawContent(CheckModel check) {
+  void _drawContent(Check check) {
     final double totalValueWithoutWaiterValue =
         check.totalValue - check.totalWaiterValue;
 

--- a/lib/src/external/services/share_plus_service_impl.dart
+++ b/lib/src/external/services/share_plus_service_impl.dart
@@ -9,16 +9,23 @@ class SharePlusCheckServiceImpl extends ShareCheckService {
       'play.google.com/store/apps/details?id=com.matopibatech.racharacha';
 
   @override
-  Future<void> shareCheck({required Uint8List imageBytes}) async =>
-      await Share.shareXFiles(
-        [
-          XFile.fromData(
-            imageBytes,
-            mimeType: 'image/png',
-            name: 'racha_racha_conta.png',
-          )
-        ],
-        text:
-            'Confira nossa divisão de conta no Racha Racha!\n Baixe o app também: $_appUrl',
-      );
+  Future<bool> shareCheck({required Uint8List imageBytes}) async {
+    final result = await Share.shareXFiles(
+      [
+        XFile.fromData(
+          imageBytes,
+          mimeType: 'image/png',
+          name: 'racha_racha_conta.png',
+        )
+      ],
+      text:
+          'Confira nossa divisão de conta no Racha Racha!\n Baixe o app também: $_appUrl',
+    );
+
+    if (result.status == ShareResultStatus.success) {
+      return true;
+    }
+
+    return false;
+  }
 }

--- a/lib/src/infra/check/adapters/sqflite_check_adapter.dart
+++ b/lib/src/infra/check/adapters/sqflite_check_adapter.dart
@@ -1,7 +1,7 @@
-import '../../../domain/check/entities/check_model.dart';
+import '../../../domain/check/entities/check.dart';
 
 class SqfliteCheckAdapter {
-  static Map<String, dynamic> toMap(CheckModel check) {
+  static Map<String, dynamic> toMap(Check check) {
     return {
       'id': check.id,
       'creationDate': check.creationDate?.toIso8601String() ??
@@ -18,8 +18,8 @@ class SqfliteCheckAdapter {
     };
   }
 
-  static CheckModel fromMap(Map<String, dynamic> map) {
-    return CheckModel(
+  static Check fromMap(Map<String, dynamic> map) {
+    return Check(
       id: map['id'] as String?,
       creationDate: map['creationDate'] != null
           ? DateTime.parse(map['creationDate'])

--- a/lib/src/infra/check/check_repository_impl.dart
+++ b/lib/src/infra/check/check_repository_impl.dart
@@ -1,8 +1,7 @@
 import 'package:dartz/dartz.dart';
-import 'package:racha_racha/src/domain/check/entities/check_model.dart';
+import 'package:racha_racha/src/domain/check/entities/check.dart';
 
 import '../../domain/check/errors/erros.dart';
-import '../../domain/check/entities/result_get_all_checks.dart';
 import '../../domain/check/repositories/check_repository.dart';
 import 'datasourcers/local_check_datasource.dart';
 
@@ -12,7 +11,7 @@ class CheckRepositoryImpl implements CheckRepository {
   CheckRepositoryImpl({required this.localDatasource});
 
   @override
-  Future<Either<Failure, ResultGetAllChecks>> getAllChecks() async {
+  Future<Either<Failure, List<Check>>> getAllChecks() async {
     try {
       final result = await localDatasource.getAllChecks();
       return Right(result);
@@ -32,7 +31,7 @@ class CheckRepositoryImpl implements CheckRepository {
   }
 
   @override
-  Future<Either<Failure, void>> createCheck({required CheckModel check}) async {
+  Future<Either<Failure, void>> createCheck({required Check check}) async {
     try {
       final result = await localDatasource.createCheck(check: check);
 

--- a/lib/src/infra/check/datasourcers/local_check_datasource.dart
+++ b/lib/src/infra/check/datasourcers/local_check_datasource.dart
@@ -1,8 +1,7 @@
-import '../../../domain/check/entities/check_model.dart';
-import '../../../domain/check/entities/result_get_all_checks.dart';
+import '../../../domain/check/entities/check.dart';
 
 abstract class LocalCheckDatasource {
-  Future<ResultGetAllChecks> getAllChecks();
-  Future<void> createCheck({required CheckModel check});
+  Future<List<Check>> getAllChecks();
+  Future<void> createCheck({required Check check});
   Future<void> deleteCheck({required String checkId});
 }

--- a/lib/src/infra/services/check_sharing_service_impl.dart
+++ b/lib/src/infra/services/check_sharing_service_impl.dart
@@ -1,0 +1,44 @@
+import 'dart:typed_data';
+
+import 'package:dartz/dartz.dart';
+
+import '../../domain/check/entities/check.dart';
+import '../../domain/check/errors/erros.dart';
+import '../../domain/check/services/check_sharing_service.dart';
+import 'generate_check_service.dart';
+import 'share_check_service.dart';
+
+class CheckSharingServiceImpl implements CheckSharingService {
+  final GenerateCheckService generateCheckService;
+  final ShareCheckService shareCheckService;
+
+  CheckSharingServiceImpl({
+    required this.generateCheckService,
+    required this.shareCheckService,
+  });
+
+  @override
+  Future<Either<Failure, Uint8List>> generateCheckImage(Check check) async {
+    try {
+      final result = await generateCheckService.generateImage(check: check);
+      return Right(result);
+    } catch (e) {
+      return Left(
+          CheckSharingServiceError(message: 'Failed to generate image: $e'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> shareCheckImage({
+    required Uint8List imageBytes,
+  }) async {
+    try {
+      final result = await shareCheckService.shareCheck(imageBytes: imageBytes);
+      return Right(result);
+    } catch (e) {
+      return Left(
+        CheckSharingServiceError(message: 'Failed to generate image: $e'),
+      );
+    }
+  }
+}

--- a/lib/src/infra/services/generate_check_service.dart
+++ b/lib/src/infra/services/generate_check_service.dart
@@ -1,9 +1,9 @@
 import 'dart:typed_data';
 
-import '../../domain/check/entities/check_model.dart';
+import '../../domain/check/entities/check.dart';
 
 abstract class GenerateCheckService {
   Future<Uint8List> generateImage({
-    required CheckModel check,
+    required Check check,
   });
 }

--- a/lib/src/infra/services/share_check_service.dart
+++ b/lib/src/infra/services/share_check_service.dart
@@ -1,5 +1,5 @@
 import 'dart:typed_data';
 
 abstract class ShareCheckService {
-  Future<void> shareCheck({required Uint8List imageBytes});
+  Future<bool> shareCheck({required Uint8List imageBytes});
 }

--- a/lib/src/presenter/screens/history/controller/history_screen_controller.dart
+++ b/lib/src/presenter/screens/history/controller/history_screen_controller.dart
@@ -2,7 +2,7 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 
-import '../../../../domain/check/entities/check_model.dart';
+import '../../../../domain/check/entities/check.dart';
 import '../../../../domain/check/usecases/get_all_checks.dart';
 
 class HistoryScreenController with ChangeNotifier {
@@ -15,8 +15,8 @@ class HistoryScreenController with ChangeNotifier {
   bool _isLoading = false;
   bool get isLoading => _isLoading;
 
-  List<CheckModel> _checks = [];
-  List<CheckModel> get checks => _checks;
+  List<Check> _checks = [];
+  List<Check> get checks => _checks;
 
   Future<void> fetchChecks() async {
     _isLoading = true;
@@ -29,7 +29,7 @@ class HistoryScreenController with ChangeNotifier {
         log(failure.message.toString());
       },
       (sucess) {
-        _checks = sucess.checks;
+        _checks = sucess;
       },
     );
     _isLoading = false;

--- a/lib/src/presenter/screens/history/controller/history_screen_controller.dart
+++ b/lib/src/presenter/screens/history/controller/history_screen_controller.dart
@@ -3,14 +3,19 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 
 import '../../../../domain/check/entities/check.dart';
+import '../../../../domain/check/usecases/share_check.dart';
 import '../../../../domain/check/usecases/get_all_checks.dart';
 
 class HistoryScreenController with ChangeNotifier {
-  final GetAllChecks getAllChecks;
+  final GetAllChecks _getAllChecks;
+  final ShareCheck _shareCheck;
+  // TODO: implementar caso de uso de deletar!
 
   HistoryScreenController({
-    required this.getAllChecks,
-  });
+    required GetAllChecks getAllChecks,
+    required ShareCheck shareCheck,
+  })  : _shareCheck = shareCheck,
+        _getAllChecks = getAllChecks;
 
   bool _isLoading = false;
   bool get isLoading => _isLoading;
@@ -22,7 +27,7 @@ class HistoryScreenController with ChangeNotifier {
     _isLoading = true;
     notifyListeners();
 
-    final result = await getAllChecks.call();
+    final result = await _getAllChecks.call();
 
     result.fold(
       (failure) {
@@ -38,5 +43,20 @@ class HistoryScreenController with ChangeNotifier {
 
   Future<void> reloadChecks() async {
     await fetchChecks();
+  }
+
+  Future<bool> shareCheck(Check check) async {
+    final result = await _shareCheck.call(check: check);
+
+    return result.fold(
+      (failure) {
+        // TODO: tratar esta falha.
+        log(failure.message);
+        return false;
+      },
+      (sucess) {
+        return sucess;
+      },
+    );
   }
 }

--- a/lib/src/presenter/screens/history/provider/history_screen_provider.dart
+++ b/lib/src/presenter/screens/history/provider/history_screen_provider.dart
@@ -3,10 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../../../../domain/check/repositories/check_repository.dart';
 import '../../../../domain/check/usecases/get_all_checks.dart';
-import '../../../../external/services/generate_check_service_impl.dart';
-import '../../../../external/services/share_plus_service_impl.dart';
-import '../../../../infra/services/generate_check_service.dart';
-import '../../../../infra/services/share_check_service.dart';
+import '../../../../domain/check/usecases/share_check.dart';
 import '../controller/history_screen_controller.dart';
 
 class HistoryScreenProvider extends StatelessWidget {
@@ -16,12 +13,6 @@ class HistoryScreenProvider extends StatelessWidget {
   @override
   Widget build(BuildContext context) => MultiProvider(
         providers: [
-          Provider<GenerateCheckService>(
-            create: (_) => GenerateCheckServiceImpl(),
-          ),
-          Provider<ShareCheckService>(
-            create: (_) => SharePlusCheckServiceImpl(),
-          ),
           Provider<GetAllChecks>(
             create: (context) => GetAllChecksImpl(
               repository: context.read<CheckRepository>(),
@@ -30,6 +21,7 @@ class HistoryScreenProvider extends StatelessWidget {
           ChangeNotifierProvider(
             create: (context) => HistoryScreenController(
               getAllChecks: context.read<GetAllChecks>(),
+              shareCheck: context.read<ShareCheck>(),
             ),
           ),
         ],

--- a/lib/src/presenter/screens/history/widgets/check_item_widget.dart
+++ b/lib/src/presenter/screens/history/widgets/check_item_widget.dart
@@ -3,7 +3,7 @@ import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
-import '../../../../domain/check/entities/check_model.dart';
+import '../../../../domain/check/entities/check.dart';
 import '../../../../infra/services/generate_check_service.dart';
 import '../../../../infra/services/share_check_service.dart';
 import '../../../shared/controllers/check_controller.dart';
@@ -14,7 +14,7 @@ import '../controller/history_screen_controller.dart';
 import 'confirm_exclusion_popup_widget.dart';
 
 class CheckItemWidget extends StatefulWidget {
-  final CheckModel check;
+  final Check check;
   final int index;
 
   const CheckItemWidget({

--- a/lib/src/presenter/screens/is_someone_drinking/widgets/is_drinking_buttons_widget.dart
+++ b/lib/src/presenter/screens/is_someone_drinking/widgets/is_drinking_buttons_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../../../domain/check/entities/check_model.dart';
+import '../../../../domain/check/entities/check.dart';
 import '../../../shared/constants/space_constants.dart';
 import '../../../shared/controllers/check_controller.dart';
 import '../../../shared/routes/app_route_manager.dart';
@@ -63,7 +63,7 @@ class IsDrikingButtonsWidget extends StatelessWidget {
 
   void _showModalIsSomeoneDrinking(
     BuildContext context,
-    CheckModel check,
+    Check check,
   ) {
     showModalBottomSheet(
       context: context,
@@ -77,7 +77,7 @@ class IsDrikingButtonsWidget extends StatelessWidget {
 
 // Novo Widget para o Modal de Confirmação
 class CheckConfirmationModal extends StatelessWidget {
-  final CheckModel check;
+  final Check check;
 
   const CheckConfirmationModal({
     Key? key,

--- a/lib/src/presenter/screens/result/check_details_screen.dart
+++ b/lib/src/presenter/screens/result/check_details_screen.dart
@@ -8,8 +8,6 @@ import '../../shared/routes/app_route_manager.dart';
 import '../../shared/constants/space_constants.dart';
 import '../../shared/controllers/check_controller.dart';
 import '../../shared/ui/widgets/will_pop_scope_widget.dart';
-import '../../../infra/services/generate_check_service.dart';
-import '../../../infra/services/share_check_service.dart';
 import 'widgets/bottom_nav_bar_widget.dart';
 import 'widgets/result_body_widget.dart';
 import 'widgets/shared_check_widget.dart';
@@ -104,8 +102,8 @@ class _CheckDetailsScreenState extends State<CheckDetailsScreen> {
             const Spacer(),
           ],
           SharedCheckWidget(
-            generateImageService: context.read<GenerateCheckService>(),
-            shareService: context.read<ShareCheckService>(),
+            // generateImageService: context.read<GenerateCheckService>(),
+            // shareService: context.read<ShareCheckService>(),
             check: widget.check,
           ),
         ],

--- a/lib/src/presenter/screens/result/check_details_screen.dart
+++ b/lib/src/presenter/screens/result/check_details_screen.dart
@@ -3,7 +3,7 @@ import 'package:intl/intl.dart';
 
 import 'package:provider/provider.dart';
 
-import '../../../domain/check/entities/check_model.dart';
+import '../../../domain/check/entities/check.dart';
 import '../../shared/routes/app_route_manager.dart';
 import '../../shared/constants/space_constants.dart';
 import '../../shared/controllers/check_controller.dart';
@@ -16,7 +16,7 @@ import 'widgets/shared_check_widget.dart';
 
 class CheckDetailsScreen extends StatefulWidget {
   final bool isFinishingCheck;
-  final CheckModel check;
+  final Check check;
 
   const CheckDetailsScreen({
     Key? key,

--- a/lib/src/presenter/screens/result/widgets/result_body_widget.dart
+++ b/lib/src/presenter/screens/result/widgets/result_body_widget.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
-import '../../../../domain/check/entities/check_model.dart';
+import '../../../../domain/check/entities/check.dart';
 import '../../../shared/constants/space_constants.dart';
 import 'result_info_widget.dart';
 
 class ResultBodyWidget extends StatelessWidget {
-  final CheckModel check;
+  final Check check;
 
   const ResultBodyWidget({
     Key? key,

--- a/lib/src/presenter/screens/result/widgets/shared_check_widget.dart
+++ b/lib/src/presenter/screens/result/widgets/shared_check_widget.dart
@@ -1,23 +1,22 @@
-import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import '../../../../domain/check/entities/check.dart';
-import '../../../../infra/services/generate_check_service.dart';
-import '../../../../infra/services/share_check_service.dart';
+import '../../../shared/controllers/check_controller.dart';
 
-class SharedCheckWidget extends StatelessWidget {
-  final ShareCheckService shareService;
-  final GenerateCheckService generateImageService;
+class SharedCheckWidget extends StatefulWidget {
   final Check check;
 
   const SharedCheckWidget({
     Key? key,
     required this.check,
-    required this.shareService,
-    required this.generateImageService,
   }) : super(key: key);
 
+  @override
+  State<SharedCheckWidget> createState() => _SharedCheckWidgetState();
+}
+
+class _SharedCheckWidgetState extends State<SharedCheckWidget> {
   @override
   Widget build(BuildContext context) => Material(
         elevation: 2,
@@ -37,22 +36,25 @@ class SharedCheckWidget extends StatelessWidget {
                   fontWeight: FontWeight.w500,
                 ),
           ),
-          onPressed: () async => await _onShareCheck(
-            check: check,
-          ),
+          onPressed: () async => await onSharePressed(),
         ),
       );
 
-  Future<void> _onShareCheck({required Check check}) async {
-    // TODO: gerar essa imagem diretamente no ShareService
-    await generateImageService
-        .generateImage(
-          check: check,
-        )
-        .then(
-          (Uint8List image) async => await shareService.shareCheck(
-            imageBytes: image,
-          ),
-        );
+  Future<void> onSharePressed() async {
+    final result =
+        await context.read<CheckController>().shareCheck(widget.check);
+
+    if (!mounted) return;
+    final messageText = 'A divisão ${(result) ? '' : 'não'} foi compartilhada!';
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          messageText,
+          style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 14),
+        ),
+        backgroundColor: !result ? Colors.red : null,
+      ),
+    );
   }
 }

--- a/lib/src/presenter/screens/result/widgets/shared_check_widget.dart
+++ b/lib/src/presenter/screens/result/widgets/shared_check_widget.dart
@@ -2,14 +2,14 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 
-import '../../../../domain/check/entities/check_model.dart';
+import '../../../../domain/check/entities/check.dart';
 import '../../../../infra/services/generate_check_service.dart';
 import '../../../../infra/services/share_check_service.dart';
 
 class SharedCheckWidget extends StatelessWidget {
   final ShareCheckService shareService;
   final GenerateCheckService generateImageService;
-  final CheckModel check;
+  final Check check;
 
   const SharedCheckWidget({
     Key? key,
@@ -43,7 +43,7 @@ class SharedCheckWidget extends StatelessWidget {
         ),
       );
 
-  Future<void> _onShareCheck({required CheckModel check}) async {
+  Future<void> _onShareCheck({required Check check}) async {
     // TODO: gerar essa imagem diretamente no ShareService
     await generateImageService
         .generateImage(

--- a/lib/src/presenter/shared/controllers/check_controller.dart
+++ b/lib/src/presenter/shared/controllers/check_controller.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../../../domain/check/repositories/check_repository.dart';
 import '../../../domain/check/entities/check.dart';
+import '../../../domain/check/usecases/share_check.dart';
 
 enum CheckState {
   totalCheckValueInvalid,
@@ -37,9 +38,12 @@ enum CheckState {
 
 class CheckController extends ChangeNotifier {
   final CheckRepository _repository;
+  final ShareCheck _shareCheck;
 
-  CheckController({required CheckRepository repository})
-      : _repository = repository;
+  CheckController(
+      {required CheckRepository repository, required ShareCheck shareCheck})
+      : _repository = repository,
+        _shareCheck = shareCheck;
 
 // deixar isso como privado?
   Check check = Check();
@@ -281,6 +285,21 @@ class CheckController extends ChangeNotifier {
       log("Erro ao setar valor total de bebida!");
     }
     notifyListeners();
+  }
+
+  Future<bool> shareCheck(Check check) async {
+    final result = await _shareCheck.call(check: check);
+
+    return result.fold(
+      (failure) {
+        // TODO: tratar esta falha.
+        log(failure.message);
+        return false;
+      },
+      (sucess) {
+        return sucess;
+      },
+    );
   }
 
   Future<void> restartCheck() async {

--- a/lib/src/presenter/shared/controllers/check_controller.dart
+++ b/lib/src/presenter/shared/controllers/check_controller.dart
@@ -3,7 +3,7 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 
 import '../../../domain/check/repositories/check_repository.dart';
-import '../../../domain/check/entities/check_model.dart';
+import '../../../domain/check/entities/check.dart';
 
 enum CheckState {
   totalCheckValueInvalid,
@@ -42,7 +42,7 @@ class CheckController extends ChangeNotifier {
       : _repository = repository;
 
 // deixar isso como privado?
-  CheckModel check = CheckModel();
+  Check check = Check();
 
   CheckState state = CheckState.idle;
 
@@ -285,13 +285,13 @@ class CheckController extends ChangeNotifier {
 
   Future<void> restartCheck() async {
     state = CheckState.idle;
-    check = CheckModel();
+    check = Check();
     msgError = "";
     await Future.delayed(Duration.zero);
     notifyListeners();
   }
 
-  Future<void> delete(CheckModel check) async {
+  Future<void> delete(Check check) async {
     _repository.deleteCheck(checkId: check.id!);
   }
 }

--- a/lib/src/presenter/shared/providers/general_widget_provider.dart
+++ b/lib/src/presenter/shared/providers/general_widget_provider.dart
@@ -2,11 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../../domain/check/repositories/check_repository.dart';
+import '../../../domain/check/services/check_sharing_service.dart';
+import '../../../domain/check/usecases/share_check.dart';
 import '../../../external/check/datasourcers/sqflite_check_datasource.dart';
 import '../../../external/services/cache/shared_preferences_cache_service.dart';
+import '../../../external/services/generate_check_service_impl.dart';
+import '../../../external/services/share_plus_service_impl.dart';
 import '../../../infra/check/check_repository_impl.dart';
 import '../../../infra/check/datasourcers/local_check_datasource.dart';
 import '../../../infra/services/cache/cache_service.dart';
+import '../../../infra/services/check_sharing_service_impl.dart';
+import '../../../infra/services/generate_check_service.dart';
+import '../../../infra/services/share_check_service.dart';
 import '../controllers/check_controller.dart';
 import '../controllers/user_controller.dart';
 
@@ -32,8 +39,26 @@ class GeneralWidgetProvider extends StatelessWidget {
               localDatasource: context.read<LocalCheckDatasource>(),
             ),
           ),
+          Provider<GenerateCheckService>(
+            create: (_) => GenerateCheckServiceImpl(),
+          ),
+          Provider<ShareCheckService>(
+            create: (_) => SharePlusCheckServiceImpl(),
+          ),
+          Provider<CheckSharingService>(
+            create: (context) => CheckSharingServiceImpl(
+              generateCheckService: context.read<GenerateCheckService>(),
+              shareCheckService: context.read<ShareCheckService>(),
+            ),
+          ),
+          Provider<ShareCheck>(
+            create: (context) => ShareCheckImpl(
+              sharingService: context.read<CheckSharingService>(),
+            ),
+          ),
           ChangeNotifierProvider<CheckController>(
             create: (context) => CheckController(
+              shareCheck: context.read<ShareCheck>(),
               repository: context.read<CheckRepository>(),
             ),
           ),

--- a/lib/src/presenter/shared/routes/app_route_manager.dart
+++ b/lib/src/presenter/shared/routes/app_route_manager.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../../domain/check/entities/check_model.dart';
+import '../../../domain/check/entities/check.dart';
 import '../../screens/history/history_screen.dart';
 import '../../screens/first/first_screen.dart';
 import '../../screens/history/provider/history_screen_provider.dart';
@@ -55,7 +55,7 @@ class AppRouteManager {
 
             final isFinishingCheck = arguments['isFinishing'] as bool;
 
-            final check = arguments['check'] as CheckModel;
+            final check = arguments['check'] as Check;
 
             return CheckDetailsScreenProvider(
               child: CheckDetailsScreen(

--- a/lib/src/presenter/shared/ui/theme/theme_config.dart
+++ b/lib/src/presenter/shared/ui/theme/theme_config.dart
@@ -37,6 +37,14 @@ class ThemeConfig {
       bodyMedium: TextStyle(color: Colors.deepPurple),
       bodySmall: TextStyle(color: Colors.deepPurple),
     ),
+    snackBarTheme: SnackBarThemeData(
+      showCloseIcon: true,
+      backgroundColor: Colors.deepPurple[500],
+      contentTextStyle: const TextStyle(
+        fontWeight: FontWeight.w600,
+        fontSize: 14,
+      ),
+    ),
     iconTheme: const IconThemeData(color: Colors.deepPurple),
   );
 }

--- a/test/src/domain/check/entities/check_model_test.dart
+++ b/test/src/domain/check/entities/check_model_test.dart
@@ -1,11 +1,10 @@
-
 import 'package:flutter_test/flutter_test.dart';
-import 'package:racha_racha/src/domain/check/entities/check_model.dart';
+import 'package:racha_racha/src/domain/check/entities/check.dart';
 
 void main() {
   group('CheckModel', () {
     test('should initialize with default values', () {
-      final model = CheckModel();
+      final model = Check();
       expect(model.totalValue, 0);
       expect(model.individualPrice, 0);
       expect(model.waiterPercentage, 0);
@@ -18,7 +17,7 @@ void main() {
     });
 
     test('should initialize with custom values', () {
-      final model = CheckModel(
+      final model = Check(
         totalValue: 100,
         individualPrice: 25,
         waiterPercentage: 10,
@@ -42,7 +41,7 @@ void main() {
     });
 
     test('should handle zero values', () {
-      final model = CheckModel(
+      final model = Check(
         totalValue: 0,
         totalPeople: 0,
         totalPeopleDrinking: 0,
@@ -54,7 +53,7 @@ void main() {
     });
 
     test('should handle large values', () {
-      final model = CheckModel(
+      final model = Check(
         totalValue: 1000000,
         individualPrice: 500000,
         waiterPercentage: 20,

--- a/test/src/external/services/generate_check_service_impl_test.dart
+++ b/test/src/external/services/generate_check_service_impl_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:racha_racha/src/domain/check/entities/check_model.dart';
+import 'package:racha_racha/src/domain/check/entities/check.dart';
 import 'package:racha_racha/src/external/services/generate_check_service_impl.dart';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -13,7 +13,7 @@ void main() {
   });
 
   test('generateImage retorna uma Uint8List não vazia', () async {
-    final check = CheckModel(
+    final check = Check(
       totalValue: 100,
       individualPrice: 25,
       waiterPercentage: 10,
@@ -29,7 +29,7 @@ void main() {
   });
 
   test('generateImage cria uma imagem com as dimensões corretas', () async {
-    final check = CheckModel(
+    final check = Check(
       totalValue: 100,
       individualPrice: 25,
       waiterPercentage: 10,


### PR DESCRIPTION
This pull request includes significant changes to the `Check` entity and related classes, as well as the introduction of a new `CheckSharingService`. The most important changes include renaming `CheckModel` to `Check`, updating all references to this entity, and modifying the `CheckRepository` and `LocalCheckDatasource` interfaces and implementations accordingly. Additionally, a new `CheckSharingService` has been introduced, and existing services have been updated to support this new functionality.

Entity and Repository Updates:

* Renamed `CheckModel` to `Check` and updated all references to this entity in the codebase. (`lib/src/domain/check/entities/check.dart`, `lib/src/domain/check/repositories/check_repository.dart`, `lib/src/infra/check/adapters/sqflite_check_adapter.dart`) [[1]](diffhunk://#diff-bd433778de7122b87ce1616be6edc9fa3339148089adcb0c8bd5fbf818d47deaL1-R1) [[2]](diffhunk://#diff-369ea6262daf3c1103b0750b8c43be13c5f1e5bd7c0a28dc77c1e5b914b1bfb9L3-R11) [[3]](diffhunk://#diff-55c8c8ec58f2b2cdd676c5ddd503e87075cdd653d9d282531956794475aeb518L1-R4)
* Updated `CheckRepository` and `LocalCheckDatasource` to use `List<Check>` instead of `ResultGetAllChecks` for retrieving checks. (`lib/src/domain/check/repositories/check_repository.dart`, `lib/src/infra/check/datasourcers/local_check_datasource.dart`) [[1]](diffhunk://#diff-369ea6262daf3c1103b0750b8c43be13c5f1e5bd7c0a28dc77c1e5b914b1bfb9L3-R11) [[2]](diffhunk://#diff-2358aa967137171866cee0d5960da8f7a9536197d871f919937275b9216f006dL1-R5)

Service and Use Case Updates:

* Introduced `CheckSharingService` for generating and sharing check images, and implemented the service. (`lib/src/domain/check/services/check_sharing_service.dart`, `lib/src/infra/services/check_sharing_service_impl.dart`) [[1]](diffhunk://#diff-db5535d4719da5b26059e58c2e344729bf8c52ca7209947dcc3da06502197ebeR1-R13) [[2]](diffhunk://#diff-35ba2e83b4e05e08133e46d7431e67968ee0ece5335d08a2235e09a555c400aeR1-R44)
* Updated `ShareCheck` use case to integrate with the new `CheckSharingService`. (`lib/src/domain/check/usecases/share_check.dart`)

Refactor and Cleanup:

* Removed `ResultGetAllChecks` class and updated all related code to handle `List<Check>` directly. (`lib/src/domain/check/entities/result_get_all_checks.dart`, `lib/src/external/check/datasourcers/sqflite_check_datasource.dart`) [[1]](diffhunk://#diff-192a2c622344863292f7510dc41283ca1a4ab417246daa5a0d371de37a661cb6L1-L7) [[2]](diffhunk://#diff-a4f6b0da8f7d4010ab4523c8be60ddc6755fe4d4e3924d08eb6a0c065e7b4718L72-R69)
* Updated `GenerateCheckService` and `ShareCheckService` to support the new `Check` entity. (`lib/src/infra/services/generate_check_service.dart`, `lib/src/infra/services/share_check_service.dart`) [[1]](diffhunk://#diff-358124b405d4e82ef673e5ffda9b5dc8c672b3e3457d266a9f93143ac403cfbfL3-R7) [[2]](diffhunk://#diff-5db18971e17220a6b931339934c5b7ac4e849dca8423395b3f7b7ce6a5c74417L4-R4)