### PR TITLE
Refactor/apply clean arch into create check

### DIFF
--- a/lib/src/domain/check/usecases/create_check.dart
+++ b/lib/src/domain/check/usecases/create_check.dart
@@ -1,15 +1,20 @@
 import 'package:dartz/dartz.dart';
 
+import '../entities/check.dart';
 import '../errors/erros.dart';
+import '../repositories/check_repository.dart';
 
 abstract class CreateCheck {
-  Future<Either<Failure, bool>> call();
+  Future<Either<Failure, void>> call({required Check check});
 }
 
 class CreateCheckImpl implements CreateCheck {
+  final CheckRepository repository;
+
+  CreateCheckImpl({required this.repository});
+
   @override
-  Future<Either<Failure, bool>> call() {
-    // TODO: implement call
-    throw UnimplementedError();
+  Future<Either<Failure, void>> call({required Check check}) {
+    return repository.createCheck(check: check);
   }
 }

--- a/lib/src/domain/check/usecases/get_all_checks.dart
+++ b/lib/src/domain/check/usecases/get_all_checks.dart
@@ -1,6 +1,6 @@
 import 'package:dartz/dartz.dart';
-import 'package:racha_racha/src/domain/check/entities/check.dart';
 
+import '../entities/check.dart';
 import '../errors/erros.dart';
 import '../repositories/check_repository.dart';
 

--- a/lib/src/external/check/datasourcers/sqflite_check_datasource.dart
+++ b/lib/src/external/check/datasourcers/sqflite_check_datasource.dart
@@ -1,6 +1,7 @@
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:uuid/uuid.dart';
+
 import '../../../infra/check/adapters/sqflite_check_adapter.dart';
 import '../../../infra/check/datasourcers/local_check_datasource.dart';
 import '../../../domain/check/entities/check.dart';
@@ -49,8 +50,7 @@ class SqfliteCheckDatasource implements LocalCheckDatasource {
   @override
   Future<void> createCheck({required Check check}) async {
     try {
-      final db = await _db; // Espera até que o banco de dados esteja pronto
-
+      final db = await _db;
       final id = const Uuid().v4();
       final updatedCheck = check.copyWith(id: id);
 
@@ -68,7 +68,7 @@ class SqfliteCheckDatasource implements LocalCheckDatasource {
   @override
   Future<List<Check>> getAllChecks() async {
     try {
-      final db = await _db; // Espera até que o banco de dados esteja pronto
+      final db = await _db;
       final List<Map<String, dynamic>> maps = await db.query(
         _tableName,
         orderBy: 'creationDate DESC',

--- a/lib/src/external/services/share_plus_service_impl.dart
+++ b/lib/src/external/services/share_plus_service_impl.dart
@@ -2,14 +2,14 @@ import 'dart:typed_data';
 
 import 'package:share_plus/share_plus.dart';
 
-import '../../infra/services/share_check_service.dart';
+import '../../infra/services/share_service.dart';
 
-class SharePlusCheckServiceImpl extends ShareCheckService {
+class SharePlusCheckServiceImpl extends ShareService {
   final String _appUrl =
       'play.google.com/store/apps/details?id=com.matopibatech.racharacha';
 
   @override
-  Future<bool> shareCheck({required Uint8List imageBytes}) async {
+  Future<bool> shareCheckImage({required Uint8List imageBytes}) async {
     final result = await Share.shareXFiles(
       [
         XFile.fromData(

--- a/lib/src/infra/check/repositories/check_repository_impl.dart
+++ b/lib/src/infra/check/repositories/check_repository_impl.dart
@@ -1,9 +1,9 @@
 import 'package:dartz/dartz.dart';
-import 'package:racha_racha/src/domain/check/entities/check.dart';
 
-import '../../domain/check/errors/erros.dart';
-import '../../domain/check/repositories/check_repository.dart';
-import 'datasourcers/local_check_datasource.dart';
+import '../../../domain/check/entities/check.dart';
+import '../../../domain/check/errors/erros.dart';
+import '../../../domain/check/repositories/check_repository.dart';
+import '../datasourcers/local_check_datasource.dart';
 
 class CheckRepositoryImpl implements CheckRepository {
   final LocalCheckDatasource localDatasource;

--- a/lib/src/infra/check/services/check_sharing_service_impl.dart
+++ b/lib/src/infra/check/services/check_sharing_service_impl.dart
@@ -2,15 +2,15 @@ import 'dart:typed_data';
 
 import 'package:dartz/dartz.dart';
 
-import '../../domain/check/entities/check.dart';
-import '../../domain/check/errors/erros.dart';
-import '../../domain/check/services/check_sharing_service.dart';
-import 'generate_check_service.dart';
-import 'share_check_service.dart';
+import '../../../domain/check/entities/check.dart';
+import '../../../domain/check/errors/erros.dart';
+import '../../../domain/check/services/check_sharing_service.dart';
+import '../../services/generate_check_service.dart';
+import '../../services/share_service.dart';
 
 class CheckSharingServiceImpl implements CheckSharingService {
   final GenerateCheckService generateCheckService;
-  final ShareCheckService shareCheckService;
+  final ShareService shareCheckService;
 
   CheckSharingServiceImpl({
     required this.generateCheckService,
@@ -33,7 +33,8 @@ class CheckSharingServiceImpl implements CheckSharingService {
     required Uint8List imageBytes,
   }) async {
     try {
-      final result = await shareCheckService.shareCheck(imageBytes: imageBytes);
+      final result =
+          await shareCheckService.shareCheckImage(imageBytes: imageBytes);
       return Right(result);
     } catch (e) {
       return Left(

--- a/lib/src/infra/services/generate_check_service.dart
+++ b/lib/src/infra/services/generate_check_service.dart
@@ -3,7 +3,5 @@ import 'dart:typed_data';
 import '../../domain/check/entities/check.dart';
 
 abstract class GenerateCheckService {
-  Future<Uint8List> generateImage({
-    required Check check,
-  });
+  Future<Uint8List> generateImage({required Check check});
 }

--- a/lib/src/infra/services/share_check_service.dart
+++ b/lib/src/infra/services/share_check_service.dart
@@ -1,5 +1,0 @@
-import 'dart:typed_data';
-
-abstract class ShareCheckService {
-  Future<bool> shareCheck({required Uint8List imageBytes});
-}

--- a/lib/src/infra/services/share_service.dart
+++ b/lib/src/infra/services/share_service.dart
@@ -1,0 +1,5 @@
+import 'dart:typed_data';
+
+abstract class ShareService {
+  Future<bool> shareCheckImage({required Uint8List imageBytes});
+}

--- a/lib/src/presenter/screens/result/provider/check_details_screen_provider.dart
+++ b/lib/src/presenter/screens/result/provider/check_details_screen_provider.dart
@@ -4,7 +4,7 @@ import 'package:provider/provider.dart';
 import '../../../../external/services/generate_check_service_impl.dart';
 import '../../../../external/services/share_plus_service_impl.dart';
 import '../../../../infra/services/generate_check_service.dart';
-import '../../../../infra/services/share_check_service.dart';
+import '../../../../infra/services/share_service.dart';
 
 class CheckDetailsScreenProvider extends StatelessWidget {
   final Widget child;
@@ -16,7 +16,7 @@ class CheckDetailsScreenProvider extends StatelessWidget {
           Provider<GenerateCheckService>(
             create: (_) => GenerateCheckServiceImpl(),
           ),
-          Provider<ShareCheckService>(
+          Provider<ShareService>(
             create: (_) => SharePlusCheckServiceImpl(),
           ),
         ],

--- a/lib/src/presenter/shared/controllers/check_controller.dart
+++ b/lib/src/presenter/shared/controllers/check_controller.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../../../domain/check/repositories/check_repository.dart';
 import '../../../domain/check/entities/check.dart';
+import '../../../domain/check/usecases/create_check.dart';
 import '../../../domain/check/usecases/share_check.dart';
 
 enum CheckState {
@@ -39,11 +40,15 @@ enum CheckState {
 class CheckController extends ChangeNotifier {
   final CheckRepository _repository;
   final ShareCheck _shareCheck;
+  final CreateCheck _createCheck;
 
-  CheckController(
-      {required CheckRepository repository, required ShareCheck shareCheck})
-      : _repository = repository,
-        _shareCheck = shareCheck;
+  CheckController({
+    required CheckRepository repository,
+    required ShareCheck shareCheck,
+    required CreateCheck createCheck,
+  })  : _repository = repository,
+        _shareCheck = shareCheck,
+        _createCheck = createCheck;
 
 // deixar isso como privado?
   Check check = Check();
@@ -64,17 +69,17 @@ class CheckController extends ChangeNotifier {
 
   Future<void> calculateCheckResult() async {
     check.totalValue += check.totalWaiterValue;
+
     if (check.isSomeoneDrinking) {
       _calculateCheckResultWithDrinkers();
-
-      await _repository.createCheck(check: check);
+      await _createCheck.call(check: check);
 
       return;
     }
 
     _calculateCheckResultWithoutDrinkers();
 
-    await _repository.createCheck(check: check);
+    await _createCheck.call(check: check);
   }
 
   void _calculateCheckResultWithoutDrinkers() {

--- a/lib/src/presenter/shared/providers/general_widget_provider.dart
+++ b/lib/src/presenter/shared/providers/general_widget_provider.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../../../domain/check/repositories/check_repository.dart';
 import '../../../domain/check/services/check_sharing_service.dart';
+import '../../../domain/check/usecases/create_check.dart';
 import '../../../domain/check/usecases/share_check.dart';
 import '../../../external/check/datasourcers/sqflite_check_datasource.dart';
 import '../../../external/services/cache/shared_preferences_cache_service.dart';
@@ -56,9 +57,15 @@ class GeneralWidgetProvider extends StatelessWidget {
               sharingService: context.read<CheckSharingService>(),
             ),
           ),
+          Provider<CreateCheck>(
+            create: (context) => CreateCheckImpl(
+              repository: context.read<CheckRepository>(),
+            ),
+          ),
           ChangeNotifierProvider<CheckController>(
             create: (context) => CheckController(
               shareCheck: context.read<ShareCheck>(),
+              createCheck: context.read<CreateCheck>(),
               repository: context.read<CheckRepository>(),
             ),
           ),

--- a/lib/src/presenter/shared/providers/general_widget_provider.dart
+++ b/lib/src/presenter/shared/providers/general_widget_provider.dart
@@ -8,12 +8,12 @@ import '../../../external/check/datasourcers/sqflite_check_datasource.dart';
 import '../../../external/services/cache/shared_preferences_cache_service.dart';
 import '../../../external/services/generate_check_service_impl.dart';
 import '../../../external/services/share_plus_service_impl.dart';
-import '../../../infra/check/check_repository_impl.dart';
+import '../../../infra/check/repositories/check_repository_impl.dart';
 import '../../../infra/check/datasourcers/local_check_datasource.dart';
 import '../../../infra/services/cache/cache_service.dart';
-import '../../../infra/services/check_sharing_service_impl.dart';
+import '../../../infra/check/services/check_sharing_service_impl.dart';
 import '../../../infra/services/generate_check_service.dart';
-import '../../../infra/services/share_check_service.dart';
+import '../../../infra/services/share_service.dart';
 import '../controllers/check_controller.dart';
 import '../controllers/user_controller.dart';
 
@@ -42,13 +42,13 @@ class GeneralWidgetProvider extends StatelessWidget {
           Provider<GenerateCheckService>(
             create: (_) => GenerateCheckServiceImpl(),
           ),
-          Provider<ShareCheckService>(
+          Provider<ShareService>(
             create: (_) => SharePlusCheckServiceImpl(),
           ),
           Provider<CheckSharingService>(
             create: (context) => CheckSharingServiceImpl(
               generateCheckService: context.read<GenerateCheckService>(),
-              shareCheckService: context.read<ShareCheckService>(),
+              shareCheckService: context.read<ShareService>(),
             ),
           ),
           Provider<ShareCheck>(


### PR DESCRIPTION
This pull request includes several changes to the `check` domain, focusing on the creation and sharing of checks, as well as some refactoring for better code organization and readability. The most important changes include modifying the `CreateCheck` use case, renaming and updating repository and service files, and updating the `CheckController` to use the new `CreateCheck` use case.

### Changes to `CreateCheck` use case:

* [`lib/src/domain/check/usecases/create_check.dart`](diffhunk://#diff-732fb1d2b7ec758d5446512e47e40ce793eaccbc9949c637d379bc2f60c17e7bR3-R18): Updated the `CreateCheck` use case to accept a `Check` object as a parameter and implemented the `CreateCheckImpl` class to call the repository's `createCheck` method.

### Refactoring and renaming:

* [`lib/src/infra/check/repositories/check_repository_impl.dart`](diffhunk://#diff-4ae125c069b594d2aaee1a6a66cc11464fcaa3bb3be629d501df3ece3a974c19L2-R6): Renamed the file from `check_repository_impl.dart` to `repositories/check_repository_impl.dart` and updated import paths accordingly.
* [`lib/src/infra/check/services/check_sharing_service_impl.dart`](diffhunk://#diff-57a6076161db7f2103caa53da2513b085d6890b63e9c5ca6c724f1e5d49290baL5-R13): Renamed the file from `services/check_sharing_service_impl.dart` to `check/services/check_sharing_service_impl.dart` and updated import paths accordingly.

### Changes to `ShareService`:

* [`lib/src/infra/services/share_check_service.dart`](diffhunk://#diff-5db18971e17220a6b931339934c5b7ac4e849dca8423395b3f7b7ce6a5c74417L1-L5): Removed the `ShareCheckService` abstract class.
* [`lib/src/infra/services/share_service.dart`](diffhunk://#diff-35fda084552a77c9cd9eaaadfad894fa93c16ac33e07d8979baaa2d8572e9bfeR1-R5): Added the `ShareService` abstract class with a method `shareCheckImage` to replace `ShareCheckService`.

### Updates to `CheckController`:

* [`lib/src/presenter/shared/controllers/check_controller.dart`](diffhunk://#diff-da7450852bffa79b9e3242f88fe893e6b1ea802d9919c0e788b8cb84050eb049R43-R51): Updated the `CheckController` to include the `CreateCheck` use case and modified the `calculateCheckResult` method to call `createCheck`. [[1]](diffhunk://#diff-da7450852bffa79b9e3242f88fe893e6b1ea802d9919c0e788b8cb84050eb049R43-R51) [[2]](diffhunk://#diff-da7450852bffa79b9e3242f88fe893e6b1ea802d9919c0e788b8cb84050eb049R72-R82)

### Provider updates:

* [`lib/src/presenter/shared/providers/general_widget_provider.dart`](diffhunk://#diff-fc08c7e3c053196acc355a61f8605532959faba0c90384d13a48c424eb41639eL45-R68): Updated the providers to use `ShareService` instead of `ShareCheckService` and added a provider for `CreateCheck`.